### PR TITLE
check for bundle existence not for classes

### DIFF
--- a/DependencyInjection/SymfonyCmfMenuExtension.php
+++ b/DependencyInjection/SymfonyCmfMenuExtension.php
@@ -43,7 +43,8 @@ class SymfonyCmfMenuExtension extends Extension
 
     public function loadSonataAdmin($config, XmlFileLoader $loader, ContainerBuilder $container)
     {
-        if ('auto' === $config['use_sonata_admin'] && !class_exists('Sonata\\DoctrinePHPCRAdminBundle\\SonataDoctrinePHPCRAdminBundle')) {
+        $bundles = $container->getParameter('kernel.bundles');
+        if ('auto' === $config['use_sonata_admin'] && !isset($bundles['SonataDoctrinePHPCRAdminBundle'])) {
             return;
         }
 


### PR DESCRIPTION
this works at this time because the kernel first registers all bundles
and processes the configuration afterwards passing the list of registered
bundles to the ContainerBuilder (see Symfony/Component/HttpKernel/Kernel.php)

(courtesy to @stof in SonataAdminExtension)
