### PR TITLE
made it possible to define a menu item to be active for a given subpath

### DIFF
--- a/ContentAwareFactory.php
+++ b/ContentAwareFactory.php
@@ -37,7 +37,11 @@ class ContentAwareFactory extends RouterAwareFactory
         if (!empty($options['content'])) {
             try {
                 $request = $this->container->get('request');
-                if ($request->attributes->get($this->contentKey) == $options['content']) {
+                if ($options['content']->getOption('currentUriPrefix')
+                    && 0 === strpos($request->getPathinfo(), $options['content']->getOption('currentUriPrefix'))
+                ) {
+                    $current = true;
+                } elseif ($request->attributes->get($this->contentKey) === $options['content']) {
                     $current = true;
                 }
             } catch (\Exception $e) {}


### PR DESCRIPTION
i am not entirely sure about the name `currentUriPrefix`
also i wonder if this should be a KnpMenu feature ..

/cc @stof

This will make it possible to f.e. make the "News" tab active for child pages, ie. http://cmf.symfony.com/news/symfony-cmf-website-update
