### PR TITLE
make content aware factory work again with other than simplecms document...

### DIFF
--- a/ContentAwareFactory.php
+++ b/ContentAwareFactory.php
@@ -37,8 +37,7 @@ class ContentAwareFactory extends RouterAwareFactory
         if (!empty($options['content'])) {
             try {
                 $request = $this->container->get('request');
-                if (class_exists('Symfony\Component\Routing\Route')
-                    && $options['content'] instanceof \Symfony\Component\Routing\Route
+                if ($options['content'] instanceof \Symfony\Component\Routing\Route
                     && $options['content']->getOption('currentUriPrefix')
                     && 0 === strpos($request->getPathinfo(), $options['content']->getOption('currentUriPrefix'))
                 ) {


### PR DESCRIPTION
...s that are routes at the same time

the recent change was assuming that content is a route (aka has a getOption method). this is true for SimpleCms documents but not for everything.
