### PR TITLE
Add en and fr admin translations

### DIFF
--- a/Admin/MenuItemAdmin.php
+++ b/Admin/MenuItemAdmin.php
@@ -12,6 +12,7 @@ use Symfony\Cmf\Bundle\MenuBundle\Document\MenuItem;
 
 class MenuItemAdmin extends Admin
 {
+    protected $translationDomain = 'SymfonyCmfMenuBundle';
     protected $contentRoot;
     protected $menuRoot;
 
@@ -29,7 +30,7 @@ class MenuItemAdmin extends Admin
     protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->with('General')
+            ->with('form.group_general')
                 ->add('parent', 'doctrine_phpcr_type_tree_model', array('root_node' => $this->menuRoot, 'choice_list' => array(), 'select_root_node' => true))
                 ->add('name', 'text', ($this->hasSubject() && null !== $this->getSubject()->getId()) ? array('attr' => array('readonly' => 'readonly')) : array())
                 ->add('label', 'text')

--- a/Admin/MultilangMenuItemAdmin.php
+++ b/Admin/MultilangMenuItemAdmin.php
@@ -38,7 +38,7 @@ class MultilangMenuItemAdmin extends MenuItemAdmin
     protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->with('General')
+            ->with('form.group_general')
                 ->add('locale', 'choice', array(
                     'choices' => array_combine($this->locales, $this->locales),
                     'empty_value' => '',

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="symfony_cmf_menu.admin" class="%symfony_cmf_menu.admin_class%">
-            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="menu" label="menu item" />
+            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="dashboard.group_menu" label_catalogue="SymfonyCmfMenuBundle" label="dashboard.label_menu_item" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument/>
             <argument>%symfony_cmf_menu.document_class%</argument>
             <argument>SonataAdminBundle:CRUD</argument>

--- a/Resources/config/multilang.admin.xml
+++ b/Resources/config/multilang.admin.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="symfony_cmf_menu.multilang.admin" class="%symfony_cmf_menu.multilang.admin_class%">
-            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="menu" label="multilang menu item" />
+            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="dashboard.group_menu" label_catalogue="SymfonyCmfMenuBundle" label="dashboard.label_multilang_menu_item" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument/>
             <argument>%symfony_cmf_menu.multilang.document_class%</argument>
             <argument>SonataAdminBundle:CRUD</argument>

--- a/Resources/translations/SymfonyCmfMenuBundle.en.yml
+++ b/Resources/translations/SymfonyCmfMenuBundle.en.yml
@@ -1,0 +1,30 @@
+dashboard:
+    group_menu: Menu
+    label_menu_item: Menu item
+    label_multilang_menu_item: Multilingual menu item
+
+breadcrumb:
+    link_menu_item_list: Menu items
+    link_menu_item_create: Create
+    link_menu_item_edit: Edit
+    link_multilang_menu_item_list: Multilingual menu items
+    link_multilang_menu_item_create: Create
+    link_multilang_menu_item_edit: Edit
+
+list:
+    label_id: Id
+    label_name: Name
+    label_label: Label
+    label_uri: URI
+    label_route: Route
+    label_locales: Locales
+
+form:
+    group_general: General
+    label_locale: Locale
+    label_parent: Parent
+    label_name: Name
+    label_label: Label
+    label_uri: URI
+    label_route: Route
+    label_content: Content

--- a/Resources/translations/SymfonyCmfMenuBundle.fr.yml
+++ b/Resources/translations/SymfonyCmfMenuBundle.fr.yml
@@ -1,0 +1,30 @@
+dashboard:
+    group_menu: Menu
+    label_menu_item: Elément de menu
+    label_multilang_menu_item: Elément de menu multilingue
+
+breadcrumb:
+    link_menu_item_list: Eléments de menu
+    link_menu_item_create: Créer
+    link_menu_item_edit: Éditer
+    link_multilang_menu_item_list: Eléments de menu multilingues
+    link_multilang_menu_item_create: Créer
+    link_multilang_menu_item_edit: Éditer
+
+list:
+    label_id: Id
+    label_name: Nom
+    label_label: Label
+    label_uri: URI
+    label_route: Route
+    label_locales: Langues
+
+form:
+    group_general: Général
+    label_locale: Langue
+    label_parent: Parent
+    label_name: Nom
+    label_label: Label
+    label_uri: URI
+    label_route: Route
+    label_content: Contenu


### PR DESCRIPTION
In these translations I used "multilingual" which seems more appropriate than "multilang".
