### PR TITLE
Locale support in currentUriPrefix

### DIFF
--- a/ContentAwareFactory.php
+++ b/ContentAwareFactory.php
@@ -82,7 +82,7 @@ class ContentAwareFactory extends RouterAwareFactory
 
                 if ($options['content'] instanceof Route && $options['content']->getOption('currentUriPrefix')) {
                     $currentUriPrefix = $options['content']->getOption('currentUriPrefix');
-                    $currentUriPrefix = \str_replace('{_locale}', $request->getLocale(), $currentUriPrefix);
+                    $currentUriPrefix = str_replace('{_locale}', $request->getLocale(), $currentUriPrefix);
                 }
 
                 if ($currentUriPrefix !== null && 0 === strpos($request->getPathinfo(), $currentUriPrefix)) {


### PR DESCRIPTION
Using str_replace() instead of preg_replace() as discussed in https://github.com/symfony-cmf/MenuBundle/pull/44#issuecomment-16372092
