### PR TITLE
[WIP] Root MenuNode to be replaced with Menu

### DIFF
--- a/Admin/MenuAdmin.php
+++ b/Admin/MenuAdmin.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MenuBundle\Admin;
+
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
+use Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode;
+use Symfony\Component\HttpFoundation\Request;
+
+class MenuAdmin extends Admin
+{
+    protected $translationDomain = 'CmfMenuBundle';
+    protected $contentRoot;
+    protected $menuRoot;
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('id', 'text')
+            ->add('name', 'text')
+            ->add('label', 'text')
+            ->add('uri', 'text')
+            ->add('route', 'text')
+        ;
+    }
+
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_menu')
+            ->add(
+                'name',
+                'text',
+                ($this->hasSubject() && null !== $this->getSubject()->getId()) ? array('attr' => array('readonly' => 'readonly')) : array())
+            ->add(
+                'parent',
+                'doctrine_phpcr_odm_tree',
+                array(
+                    'root_node' => $this->root,
+                    'choice_list' => array(), 
+                    'select_root_node' => true
+                )
+            )
+            ->end()
+        ;
+
+        $formMapper->with('form.group_root')
+            ->add('label', 'text')
+            ->add('route', 'text', array('required' => false))
+            ->add('uri', 'text', array('required' => false))
+            ->add(
+                'content',
+                'doctrine_phpcr_odm_tree',
+                array('root_node' => $this->contentRoot, 'choice_list' => array(), 'required' => false)
+            )
+            ->end()
+        ;
+
+        $subject = $this->getSubject();
+        $isNew = $subject->getId() ? false : true;
+
+        if (false === $isNew) {
+            $formMapper
+                ->with('form.group_items', array())
+                ->add('children', 'doctrine_phpcr_odm_tree_manager', array(
+                    'root' => $this->menuRoot,
+                    'edit_in_overlay' => false,
+                    'create_in_overlay' => false,
+                ), array(
+                    'help' => 'help.items_help'
+                ))
+                ->end()
+                ;
+        }
+    }
+
+    protected function configureShowField(ShowMapper $showMapper)
+    {
+        $showMapper
+            ->add('id', 'text')
+            ->add('name', 'text')
+            ->add('label', 'text')
+            ->add('uri', 'text')
+            ->add('content', 'text')
+            ;
+    }
+
+    /**
+     * @return MenuNode
+     */
+    public function getNewInstance()
+    {
+        $new = parent::getNewInstance();
+
+        if ($this->hasRequest()) {
+            $parentId = $this->getRequest()->query->get('parent');
+            if (null !== $parentId) {
+                $new->setParent($this->getModelManager()->find(null, $parentId));
+            }
+        }
+
+        return $new;
+    }
+
+    public function getExportFormats()
+    {
+        return array();
+    }
+
+    public function setContentRoot($contentRoot)
+    {
+        $this->contentRoot = $contentRoot;
+    }
+
+    public function setMenuRoot($menuRoot)
+    {
+        $this->menuRoot = $menuRoot;
+    }
+
+    public function setContentTreeBlock($contentTreeBlock)
+    {
+        $this->contentTreeBlock = $contentTreeBlock;
+    }
+
+    /**
+     * Return the content tree to show at the left, current node (or parent for new ones) selected
+     *
+     * @param string $position
+     *
+     * @return array
+     */
+    public function getBlocks($position)
+    {
+        if ('left' == $position) {
+            $selected = ($this->hasSubject() && $this->getSubject()->getId()) ? $this->getSubject()->getId(
+            ) : ($this->hasRequest() ? $this->getRequest()->query->get('parent') : null);
+            return array(
+                array(
+                    'type' => 'sonata_admin_doctrine_phpcr.tree_block',
+                    'settings' => array('selected' => $selected)
+                )
+            );
+        }
+    }
+}

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -8,6 +8,7 @@ use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
 use Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode;
 use Symfony\Component\HttpFoundation\Request;
+use Knp\Menu\ItemInterface as MenuItemInterface;
 
 class MenuNodeAdmin extends Admin
 {
@@ -124,5 +125,84 @@ class MenuNodeAdmin extends Admin
                 )
             );
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildBreadcrumbs($action, MenuItemInterface $menu = null)
+    {
+        $menuNodeNode = parent::buildBreadcrumbs($action, $menu);
+
+        if ($action != 'edit') {
+            return $menuNodeNode;
+        }
+
+        $menuDoc = $this->getMenuForSubject($this->getSubject());
+        $pool = $this->getConfigurationPool();
+        $menuAdmin = $pool->getAdminByClass(
+            'Symfony\Cmf\Bundle\MenuBundle\Document\MultilangMenu'
+        );
+        $menuAdmin->setSubject($menuDoc);
+        $menuEditNode = $menuAdmin->buildBreadcrumbs($action, $menu);
+        if ($menuAdmin->isGranted('EDIT' && $menuAdmin->hasRoute('edit'))) {
+            $menuEditNode->setUri(
+                $menuAdmin->generateUrl('edit', array(
+                    'id' => $this->getUrlsafeIdentifier($menuDoc)
+                ))
+            );
+        }
+
+        $menuNodeNode->setParent(null);
+        $current = $menuEditNode->addChild($menuNodeNode);
+
+        return $current;
+    }
+
+    protected function getMenuForSubject(MenuNode $subject)
+    {
+        $id = $subject->getId();
+
+        $menuId = $this->getMenuIdForNodeId($id);
+
+        $menu = $this->modelManager->find(null, $menuId);
+
+        return $menu;
+    }
+
+    protected function getMenuIdForNodeId($id)
+    {
+        // I wonder if this could be simplified in Phpcr/PathHelper
+        //
+        // $relPath = PathHelper::removeBasePath($this->menuRoot, $id);
+        // $menuId = PathHelper:splicePath($relPath, 0, 1);
+
+        if (0 !== strpos($id, $this->menuRoot)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Cannot find base path "%s" in menu node ID "%s"', $this->menuRoot, $id
+            ));
+        }
+
+        $relPath = substr($id, strlen($this->menuRoot) + 1);
+        $parts = explode('/', $relPath);
+
+        if (count($parts) == 0) {
+            throw new \InvalidArgumentException(sprintf(
+                'ID for menu node "%s" is the same as root path "%s" - this is strange.',
+                $id, $rootPath
+            ));
+        }
+
+        if (count($parts) == 1) {
+            throw new \InvalidArgumentException(sprintf(
+                'MenuNode "%s" seems to hold the position reserved for a Menu. This should not happen',
+                $id
+            ));
+        }
+
+        $first = $parts[0];
+        $menuId = sprintf('%s/%s', $this->menuRoot, $first);
+
+        return $menuId;
     }
 }

--- a/Admin/MultilangMenuAdmin.php
+++ b/Admin/MultilangMenuAdmin.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MenuBundle\Admin;
+
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+
+class MultilangMenuAdmin extends MenuAdmin
+{
+    /**
+     * Those two properties are needed to make it possible
+     * to have 2 Admin classes for the same Document / Entity
+     */
+    protected $baseRouteName = 'admin_bundle_menu_multilangmenu_list';
+    protected $baseRoutePattern = 'bundle/menu/multilangmenu';
+
+    /**
+     * @var array
+     */
+    protected $locales;
+
+    /**
+     * @param string $code
+     * @param string $class
+     * @param string $baseControllerName
+     * @param array  $locales
+     */
+    public function __construct($code, $class, $baseControllerName, $locales)
+    {
+        parent::__construct($code, $class, $baseControllerName);
+
+        $this->locales = $locales;
+    }
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        parent::configureListFields($listMapper);
+        $listMapper
+            ->add('locales', 'choice', array('template' => 'SonataDoctrinePHPCRAdminBundle:CRUD:locales.html.twig'))
+        ;
+    }
+
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_menu')
+                ->add('locale', 'choice', array(
+                    'choices' => array_combine($this->locales, $this->locales),
+                    'empty_value' => '',
+                ))
+            ->end()
+        ;
+
+        parent::configureFormFields($formMapper);
+    }
+
+    public function getNewInstance()
+    {
+        $new = parent::getNewInstance();
+
+        if ($this->hasRequest()) {
+            $currentLocale = $this->getRequest()->attributes->get('_locale');
+
+            if (in_array($currentLocale, $this->locales)) {
+                $meta = $this->getModelManager()->getMetadata(get_class($new));
+                $meta->setFieldValue($new, $meta->localeMapping, $currentLocale);
+            }
+        }
+
+        return $new;
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+* **2013-06-26**: Introduced "Menu" nodes to act as root menu nodes and updated
+                  admin interface to reflect this. Migrate each of your root
+                  menu nodes as follows:
+                  
+                  ````
+                  $ php app/console doctrine:phpcr:node:touch --set-prop=phpcr:class="Symfony\\Cmf\\Bundle\\MenuBUndle\\Document\\Menu" /path/to/root/menu/node
+                  ````
+
 * **2013-06-21**: Added the missing options from knp-menu to the MenuNode
 * **2013-06-12**: [Document] Renamed "strongContent" to "hardContent" to better
                   reflect the PHPCR terminology

--- a/DependencyInjection/CmfMenuExtension.php
+++ b/DependencyInjection/CmfMenuExtension.php
@@ -17,7 +17,25 @@ class CmfMenuExtension extends Extension
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
 
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader(
+            $container, 
+            new FileLocator(__DIR__.'/../Resources/config')
+        );
+
+        $keys = array(
+            'menu_document_class',
+            'node_document_class',
+            'menu_basepath',
+            'document_manager_name',
+        );
+
+        foreach ($keys as $key) {
+            $container->setParameter(
+                $this->getAlias() . '.'. $key, 
+                $config[$key]
+            );
+        }
+
         $loader->load('phpcr-menu.xml');
 
         $this->loadVoters($config, $container);
@@ -30,15 +48,15 @@ class CmfMenuExtension extends Extension
             if ($config['multilang']['use_sonata_admin']) {
                 $this->loadSonataAdmin($config['multilang'], $loader, $container, 'multilang.');
             }
+
             if (isset($config['multilang']['document_class'])) {
                 $container->setParameter($this->getAlias() . '.multilang.document_class', $config['multilang']['document_class']);
             }
 
-            $container->setParameter($this->getAlias() . '.multilang.locales', $config['multilang']['locales']);
-        }
-
-        if (isset($config['document_class'])) {
-            $container->setParameter($this->getAlias() . '.document_class', $config['document_class']);
+            $container->setParameter(
+                $this->getAlias() . '.multilang.locales', 
+                $config['multilang']['locales']
+            );
         }
 
         $container->setParameter($this->getAlias() . '.menu_basepath', $config['menu_basepath']);
@@ -49,6 +67,7 @@ class CmfMenuExtension extends Extension
         $factory->replaceArgument(1, new Reference($config['content_url_generator']));
 
         $contentBasepath = $config['content_basepath'];
+
         if (null === $contentBasepath) {
             if ($container->hasParameter('cmf_core.content_basepath')) {
                 $contentBasepath = $container->getParameter('cmf_core.content_basepath');
@@ -56,6 +75,7 @@ class CmfMenuExtension extends Extension
                 $contentBasepath = '/cms/content';
             }
         }
+
         $container->setParameter($this->getAlias() . '.content_basepath', $contentBasepath);
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,7 +17,8 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('menu_basepath')->defaultValue('/cms/menu')->end()
                 ->scalarNode('document_manager_name')->defaultValue('default')->end()
                 ->scalarNode('admin_class')->defaultNull()->end()
-                ->scalarNode('document_class')->defaultNull()->end()
+                ->scalarNode('menu_document_class')->defaultNull()->end()
+                ->scalarNode('node_document_class')->defaultNull()->end()
 
                 ->scalarNode('content_url_generator')->defaultValue('router')->end()
 
@@ -47,7 +48,8 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue('auto')
                         ->end()
                         ->scalarNode('admin_class')->defaultNull()->end()
-                        ->scalarNode('document_class')->defaultNull()->end()
+                        ->scalarNode('menu_document_class')->defaultNull()->end()
+                        ->scalarNode('node_document_class')->defaultNull()->end()
                         ->arrayNode('locales')
                             ->isRequired()
                             ->requiresAtLeastOneElement()

--- a/Document/Menu.php
+++ b/Document/Menu.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MenuBundle\Document;
+
+/**
+ * This class represents a menu
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class Menu extends MenuNode
+{
+}
+

--- a/Document/MultilangMenu.php
+++ b/Document/MultilangMenu.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MenuBundle\Document;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+
+/**
+ * This class represents a multi-lang menu
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class MultilangMenu extends MultilangMenuNode
+{
+}

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -5,14 +5,22 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="cmf_menu.admin_class">Symfony\Cmf\Bundle\MenuBundle\Admin\MenuNodeAdmin</parameter>
+        <parameter key="cmf_menu.menu_admin_class">Symfony\Cmf\Bundle\MenuBundle\Admin\MenuAdmin</parameter>
+        <parameter key="cmf_menu.node_admin_class">Symfony\Cmf\Bundle\MenuBundle\Admin\MenuNodeAdmin</parameter>
     </parameters>
 
     <services>
-        <service id="cmf_menu.admin" class="%cmf_menu.admin_class%">
-            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="dashboard.group_menu" label_catalogue="CmfMenuBundle" label="dashboard.label_menu_node" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+        <service id="cmf_menu.menu_admin" class="%cmf_menu.menu_admin_class%">
+            <tag 
+                name="sonata.admin" 
+                manager_type="doctrine_phpcr" 
+                group="dashboard.group_menu" 
+                label_catalogue="CmfMenuBundle" 
+                label="dashboard.label_menu" 
+                label_translator_strategy="sonata.admin.label.strategy.underscore" 
+                />
             <argument/>
-            <argument>%cmf_menu.document_class%</argument>
+            <argument>%cmf_menu.menu_document_class%</argument>
             <argument>SonataAdminBundle:CRUD</argument>
 
             <call method="setRouteBuilder">
@@ -29,6 +37,32 @@
 
         </service>
 
+        <service id="cmf_menu.node_admin" class="%cmf_menu.node_admin_class%">
+            <tag 
+                name="sonata.admin" 
+                manager_type="doctrine_phpcr" 
+                group="dashboard.group_menu" 
+                label_catalogue="CmfMenuBundle" 
+                label="dashboard.label_menu_node" 
+                label_translator_strategy="sonata.admin.label.strategy.underscore" 
+            />
+            <argument/>
+            <argument>%cmf_menu.node_document_class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setContentRoot">
+                <argument>%cmf_menu.content_basepath%</argument>
+            </call>
+
+            <call method="setMenuRoot">
+                <argument>%cmf_menu.menu_basepath%</argument>
+            </call>
+
+        </service>
     </services>
 
 </container>

--- a/Resources/config/doctrine/Menu.phpcr.xml
+++ b/Resources/config/doctrine/Menu.phpcr.xml
@@ -1,0 +1,13 @@
+<doctrine-mapping
+    xmlns="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping
+    https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd"
+    >
+
+    <document
+        name="Symfony\Cmf\Bundle\MenuBundle\Document\Menu"
+        >
+    </document>
+
+</doctrine-mapping>

--- a/Resources/config/doctrine/MultilangMenu.phpcr.xml
+++ b/Resources/config/doctrine/MultilangMenu.phpcr.xml
@@ -1,0 +1,12 @@
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/phpcr/doctrine-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <document
+        name="Symfony\Cmf\Bundle\MenuBundle\Document\MultilangMenu"
+        translator="attribute"
+        >
+    </document>
+
+</doctrine-mapping>
+
+

--- a/Resources/config/multilang.admin.xml
+++ b/Resources/config/multilang.admin.xml
@@ -5,14 +5,50 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="cmf_menu.multilang.admin_class">Symfony\Cmf\Bundle\MenuBundle\Admin\MultilangMenuNodeAdmin</parameter>
+        <parameter key="cmf_menu.multilang.menu_admin_class">Symfony\Cmf\Bundle\MenuBundle\Admin\MultilangMenuAdmin</parameter>
+        <parameter key="cmf_menu.multilang.node_admin_class">Symfony\Cmf\Bundle\MenuBundle\Admin\MultilangMenuNodeAdmin</parameter>
     </parameters>
 
     <services>
-        <service id="cmf_menu.multilang.admin" class="%cmf_menu.multilang.admin_class%">
-            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="dashboard.group_menu" label_catalogue="CmfMenuBundle" label="dashboard.label_multilang_menu_node" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+        <service id="cmf_menu.multilang.menu_admin" class="%cmf_menu.multilang.menu_admin_class%">
+            <tag 
+                name="sonata.admin" 
+                manager_type="doctrine_phpcr" 
+                group="dashboard.group_menu" 
+                label_catalogue="CmfMenuBundle" 
+                label="dashboard.label_multilang_menu" 
+                label_translator_strategy="sonata.admin.label.strategy.underscore" 
+            />
             <argument/>
-            <argument>%cmf_menu.multilang.document_class%</argument>
+            <argument>%cmf_menu.multilang.menu_document_class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+            <argument>%cmf_menu.multilang.locales%</argument>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+
+            <call method="setContentRoot">
+                <argument>%cmf_menu.content_basepath%</argument>
+            </call>
+
+            <call method="setMenuRoot">
+                <argument>%cmf_menu.menu_basepath%</argument>
+            </call>
+
+        </service>
+
+        <service id="cmf_menu.multilang.node_admin" class="%cmf_menu.multilang.node_admin_class%">
+            <tag 
+                name="sonata.admin" 
+                manager_type="doctrine_phpcr" 
+                group="dashboard.group_menu" 
+                label_catalogue="CmfMenuBundle" 
+                label="dashboard.label_multilang_menu_node" 
+                label_translator_strategy="sonata.admin.label.strategy.underscore" 
+            />
+            <argument/>
+            <argument>%cmf_menu.multilang.node_document_class%</argument>
             <argument>SonataAdminBundle:CRUD</argument>
             <argument>%cmf_menu.multilang.locales%</argument>
 

--- a/Resources/config/phpcr-menu.xml
+++ b/Resources/config/phpcr-menu.xml
@@ -5,12 +5,14 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="cmf_menu.provider_class">Symfony\Cmf\Bundle\MenuBundle\Provider\PHPCRMenuProvider</parameter>
-        <parameter key="cmf_menu.factory_class">Symfony\Cmf\Bundle\MenuBundle\ContentAwareFactory</parameter>
         <parameter key="cmf_menu.current_item_voter.uri_prefix_class">Symfony\Cmf\Bundle\MenuBundle\Voter\UriPrefixVoter</parameter>
         <parameter key="cmf_menu.current_item_voter.content_identity_class">Symfony\Cmf\Bundle\MenuBundle\Voter\RequestContentIdentityVoter</parameter>
-        <parameter key="cmf_menu.document_class">Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode</parameter>
-        <parameter key="cmf_menu.multilang.document_class">Symfony\Cmf\Bundle\MenuBundle\Document\MultilangMenuNode</parameter>
+        <parameter key="cmf_menu.provider_class">Symfony\Cmf\Bundle\MenuBundle\Provider\PHPCRMenuProvider</parameter>
+        <parameter key="cmf_menu.factory_class">Symfony\Cmf\Bundle\MenuBundle\ContentAwareFactory</parameter>
+        <parameter key="cmf_menu.menu_document_class">Symfony\Cmf\Bundle\MenuBundle\Document\Menu</parameter>
+        <parameter key="cmf_menu.node_document_class">Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode</parameter>
+        <parameter key="cmf_menu.multilang.menu_document_class">Symfony\Cmf\Bundle\MenuBundle\Document\MultilangMenu</parameter>
+        <parameter key="cmf_menu.multilang.node_document_class">Symfony\Cmf\Bundle\MenuBundle\Document\MultilangMenuNode</parameter>
     </parameters>
 
     <services>

--- a/Resources/translations/CmfMenuBundle.de.yml
+++ b/Resources/translations/CmfMenuBundle.de.yml
@@ -1,13 +1,23 @@
 dashboard:
     group_menu: Menü
+    label_menu: Menüs
     label_menu_node: Menüeintrag
+    label_multilang_menu: Mehrsprachige menus
     label_multilang_menu_node: Mehrsprachiger Menüeintrag
 
 breadcrumb:
+    link_menu_list: Menus
+    link_menu_create: Erstellen
+    link_menu_edit: Bearbeiten
+    link_menu_delete: Löschen
     link_menu_node_list: Menüeintrag
     link_menu_node_create: Erstellen
     link_menu_node_edit: Bearbeiten
     link_menu_node_delete: Löschen
+    link_multilang_menu_list: Multilingual menus
+    link_multilang_menu_create: Erstellen
+    link_multilang_menu_edit: Bearbieten
+    link_multilang_menu_delete: Löschen
     link_multilang_menu_node_list: Mehrsprachige Menüknoten
     link_multilang_menu_node_create: Erstellen
     link_multilang_menu_node_edit: Bearbeiten
@@ -23,6 +33,10 @@ list:
 
 form:
     group_general: Allgemein
+    group_menu: Menü
+    group_items: Einträge
+    group_root: Menü Wurzel
+    label_children: Einträge
     label_locale: Sprache
     label_parent: Übergeordnet
     label_name: Name
@@ -30,3 +44,6 @@ form:
     label_uri: URI
     label_route: Route
     label_content: Inhalt
+
+help:
+    items_help: Klicken Sie auf ein Element, um es zu bearbeiten

--- a/Resources/translations/CmfMenuBundle.en.yml
+++ b/Resources/translations/CmfMenuBundle.en.yml
@@ -1,13 +1,23 @@
 dashboard:
     group_menu: Menu
+    label_menu: Menus
+    label_multilang_menu: Multilingual menus
     label_menu_node: Menu node
     label_multilang_menu_node: Multilingual menu node
 
 breadcrumb:
-    link_menu_node_list: Menu nodes
+    link_menu_list: Menus
+    link_menu_create: Create
+    link_menu_edit: Edit
+    link_menu_delete: Delete
+    link_menu_node_list: Menus nodes
     link_menu_node_create: Create
     link_menu_node_edit: Edit
     link_menu_node_delete: Delete
+    link_multilang_menu_list: Multilingual menus
+    link_multilang_menu_create: Create
+    link_multilang_menu_edit: Edit
+    link_multilang_menu_delete: Delete
     link_multilang_menu_node_list: Multilingual menu nodes
     link_multilang_menu_node_create: Create
     link_multilang_menu_node_edit: Edit
@@ -23,6 +33,10 @@ list:
 
 form:
     group_general: General
+    group_menu: Menu
+    group_items: Items
+    group_root: Menu root node
+    label_children: Items
     label_locale: Locale
     label_parent: Parent
     label_name: Name
@@ -30,3 +44,6 @@ form:
     label_uri: URI
     label_route: Route
     label_content: Content
+
+help:
+    items_help: Expand and click and item to edit, right click to create a new item.

--- a/Resources/translations/CmfMenuBundle.fr.yml
+++ b/Resources/translations/CmfMenuBundle.fr.yml
@@ -1,13 +1,23 @@
 dashboard:
     group_menu: Menu
+    label_menu: Menus
+    label_multilang_menu: Menus multilingue
     label_menu_node: Elément de menu
     label_multilang_menu_node: Elément de menu multilingue
 
 breadcrumb:
+    link_menu_list: Menus
+    link_menu_create: Créer
+    link_menu_edit: Editer
+    link_menu_delete: Supprimer
     link_menu_node_list: Eléments de menu
     link_menu_node_create: Créer
     link_menu_node_edit: Éditer
     link_menu_node_delete: Supprimer
+    link_multilang_menu_list: Menus multilingue
+    link_multilang_menu_create: Créer
+    link_multilang_menu_edit: Editer
+    link_multilang_menu_delete: Supprimer
     link_multilang_menu_node_list: Eléments de menu multilingues
     link_multilang_menu_node_create: Créer
     link_multilang_menu_node_edit: Éditer
@@ -22,7 +32,11 @@ list:
     label_locales: Langues
 
 form:
-    group_general: Général
+    group_general: Générale
+    group_menu: Menu
+    group_items: Éléments
+    group_root: Racine de menu
+    label_children: Éléments
     label_locale: Langue
     label_parent: Parent
     label_name: Nom
@@ -30,3 +44,6 @@ form:
     label_uri: URI
     label_route: Route
     label_content: Contenu
+
+help:
+    items_help: Cliquez sur un élément pour le modifier

--- a/Tests/Functional/Admin/MenuAdminTest.php
+++ b/Tests/Functional/Admin/MenuAdminTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MenuBundle\Tests\Functional\Admin\MenuNodeAdminTest;
+
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+
+class MenuAdminTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        $this->db('PHPCR')->loadFixtures(array(
+            'Symfony\Cmf\Bundle\MenuBundle\Tests\Functional\DataFixtures\PHPCR\LoadMenuData',
+        ));
+        $this->client = $this->createClient();
+    }
+
+    public function testMenuList()
+    {
+        $crawler = $this->client->request('GET', '/admin/bundle/menu/menu/list');
+        $res = $this->client->getResponse();
+        $this->assertEquals(200, $res->getStatusCode());
+        $this->assertCount(1, $crawler->filter('html:contains("test-menu")'));
+    }
+
+    public function testMenuEdit()
+    {
+        $crawler = $this->client->request('GET', '/admin/bundle/menu/menu/test/test-menu/edit');
+        $res = $this->client->getResponse();
+        $this->assertEquals(200, $res->getStatusCode());
+        $this->assertCount(1, $crawler->filter('html:contains("test-menu")'));
+    }
+
+    public function testMenuCreate()
+    {
+        $crawler = $this->client->request('GET', '/admin/bundle/menu/menu/create');
+        $res = $this->client->getResponse();
+        $this->assertEquals(200, $res->getStatusCode());
+    }
+}

--- a/Tests/Functional/Admin/MenuNodeAdminTest.php
+++ b/Tests/Functional/Admin/MenuNodeAdminTest.php
@@ -6,19 +6,8 @@ use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
 
 class MenuNodeAdminTest extends BaseTestCase
 {
-    public function setUp()
-    {
-        $this->db('PHPCR')->loadFixtures(array(
-            'Symfony\Cmf\Bundle\MenuBundle\Tests\Functional\DataFixtures\PHPCR\LoadMenuData',
-        ));
-        $this->client = $this->createClient();
-    }
-
     public function testDashboard()
     {
-        $crawler = $this->client->request('GET', '/admin/dashboard');
-        $res = $this->client->getResponse();
-        $this->assertEquals(200, $res->getStatusCode());
-        $this->assertCount(1, $crawler->filter('html:contains("dashboard.label_menu_node")'));
+        $this->markTestIncomplete();
     }
 }

--- a/Tests/Functional/App/config/routing.yml
+++ b/Tests/Functional/App/config/routing.yml
@@ -1,0 +1,10 @@
+fos_js_routing:
+    resource: @FOSJsRoutingBundle/Resources/config/routing/routing.xml
+
+cmf_tree:
+    resource: .
+    type: 'cmf_tree'
+
+tree:
+    resource: "@SonataDoctrinePHPCRAdminBundle/Resources/config/routing/phpcrodmbrowser.xml"
+    prefix: /phpcrodmbrowser

--- a/Tests/Functional/DataFixtures/PHPCR/LoadMenuData.php
+++ b/Tests/Functional/DataFixtures/PHPCR/LoadMenuData.php
@@ -6,6 +6,7 @@ use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode;
+use Symfony\Cmf\Bundle\MenuBundle\Document\Menu;
 
 class LoadMenuData implements FixtureInterface, DependentFixtureInterface
 {
@@ -20,10 +21,17 @@ class LoadMenuData implements FixtureInterface, DependentFixtureInterface
     {
         $root = $manager->find(null, '/test');
 
-        $menu = new MenuNode;
-        $menu->setName('Test Menu');
+        $menu = new Menu;
+        $menu->setName('test-menu');
         $menu->setParent($root);
         $manager->persist($menu);
+
+        $menuNode = new MenuNode;
+        $menuNode->setParent($menu);
+        $menuNode->setLabel('item1');
+        $menuNode->setName('item1');
+        $manager->persist($menuNode);
+
         $manager->flush();
     }
 }

--- a/Tests/Resources/app/config/cmf_menu.yml
+++ b/Tests/Resources/app/config/cmf_menu.yml
@@ -1,3 +1,3 @@
 cmf_menu:
     use_sonata_admin: true
-    menu_basepath: /cms/menu
+    menu_basepath: /test/test-menu

--- a/Tests/Unit/Admin/MenuNodeAdminTest.php
+++ b/Tests/Unit/Admin/MenuNodeAdminTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\MenuBundle\Tests\Unit\Admin;
+
+use Symfony\Cmf\Bundle\MenuBundle\Admin\MenuNodeAdmin;
+
+class MenuNodeAdminTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->admin = new MenuNodeAdmin('code', 'Class', 'SomeController', array('en'));
+        $this->menuNode = $this->getMock('Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode');
+        $this->modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+    }
+
+    public function provideGetMenuForSubject()
+    {
+        return array(
+            // invalid
+            array('/cms/menu', '/cms/menu/main', array(
+                'exception' => 'InvalidArgumentException',
+            )),
+
+            // valid
+            array('/cms/menu', '/cms/menu/main/foobar', array(
+                'find' => '/cms/menu/main',
+            )),
+
+            // valid
+            array('/cms/menu', '/cms/menu/main/foobar/barfoo', array(
+                'find' => '/cms/menu/main',
+            )),
+        );
+    }
+
+    /**
+     * @dataProvider provideGetMenuForSubject
+     */
+    public function testGetMenuIdForSubject($basePath, $menuPath, $options)
+    {
+        $options = array_merge(array(
+            'exception' => null,
+            'find' => false,
+        ), $options);
+
+        $this->admin->setMenuRoot($basePath);
+        $this->admin->setModelManager($this->modelManager);
+
+        $this->menuNode->expects($this->once())
+            ->method('getId')
+            ->will($this->returnValue($menuPath));
+
+        if ($options['exception']) {
+            $this->setExpectedException($options['exception']);
+        }
+
+        if ($options['find']) {
+            $this->modelManager->expects($this->once())
+                ->method('find')
+                ->with(null, $options['find']);
+        }
+
+        $refl = new \ReflectionClass($this->admin);
+        $method = $refl->getMethod('getMenuForSubject');
+        $method->setAccessible(true);
+        $res = $method->invokeArgs($this->admin, array($this->menuNode));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     },
     "require-dev": {
         "symfony-cmf/testing": "1.0.*",
-        "symfony/monolog-bundle": "~2.2",
-        "sonata-project/doctrine-phpcr-admin-bundle": "1.0.*"
+        "sonata-project/doctrine-phpcr-admin-bundle": "1.0.*",
+        "symfony/monolog-bundle": "2.2.*"
     },
     "suggest": {
         "sonata-project/doctrine-phpcr-admin-bundle": "if you want to have editing capabilities"


### PR DESCRIPTION
This PR introduces new Menu classes which are the "root" menu nodes.

The items (children) of the Menu documents will be managed with the tree manager form type.
- Enables only menus to be listed in the admin
- Will allow menu node creation, edition and reordering from the menu edit interface

Although the support for overlays seems broken at least as far as I can tell.
