### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: php
 
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
 env:
   - SYMFONY_VERSION=2.1.*
   - SYMFONY_VERSION=2.2.*
+  - SYMFONY_VERSION=2.3.*
 
 before_script:
+  - composer self-update
   - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
-  - composer install --dev
+  - composer install --dev --no-interaction --no-progress --prefer-source
   - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
 script: phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,10 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": false,
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.1,<2.3-dev",
+        "symfony/framework-bundle": "~2.1",
         "doctrine/phpcr-bundle": "1.0.*",
         "doctrine/phpcr-odm": "1.0.*",
         "knplabs/knp-menu-bundle": "1.1.*"


### PR DESCRIPTION
Include:
- Added Symfony 2.3 to the list of dependencies to test. It is out now and it I think it's worth to find out, what is missing to support it officially
- Added PHP 5.4 and 5.5 to the interpreter to test. It doesn't hurt and may be helpful
- Added `"prefer-stable": true` to `composer.json`. Dependencies werent installable otherwise.
