### PR TITLE
Fix renamed configuration of dependency

### DIFF
--- a/Resources/config/phpcr-menu.xml
+++ b/Resources/config/phpcr-menu.xml
@@ -26,7 +26,7 @@
         <service id="cmf_menu.factory" class="%cmf_menu.factory_class%">
             <argument type="service" id="router"/>
             <argument/> <!-- content url generator -->
-            <argument type="service" id="symfony_cmf_core.publish_workflow_checker"/>
+            <argument type="service" id="cmf_core.publish_workflow_checker"/>
             <argument type="service" id="logger"/>
         </service>
 


### PR DESCRIPTION
Configuration options of `CoreBundle` changed from `symfony_cmf_core.*` to `cmf_core.*`
