### PR TITLE
drop symfony 2.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.5
 
 env:
-  - SYMFONY_VERSION=2.1.*
   - SYMFONY_VERSION=2.2.*
   - SYMFONY_VERSION=2.3.*
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "prefer-stable": false,
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.1",
+        "symfony/framework-bundle": "~2.2",
         "doctrine/phpcr-bundle": "1.0.*",
         "doctrine/phpcr-odm": "1.0.*",
         "knplabs/knp-menu-bundle": "1.1.*",


### PR DESCRIPTION
expecting the Psr0 logger instead of the monolog interface breaks symfony 2.1 compatibility. i suggest we don't do big BC stuff but just drop sf 2.1 support. half of cmf does not support it anyways.
