### PR TITLE
fixing publishable flag to be the same as in StaticContent

### DIFF
--- a/Document/MenuNode.php
+++ b/Document/MenuNode.php
@@ -94,7 +94,7 @@ class MenuNode implements NodeInterface, PublishWorkflowInterface
     /**
      * @PHPCRODM\Boolean()
      */
-    protected $isPublishable = true;
+    protected $publishable = true;
 
     /**
      * @PHPCRODM\Date()
@@ -523,12 +523,12 @@ class MenuNode implements NodeInterface, PublishWorkflowInterface
 
     public function isPublishable()
     {
-        return $this->isPublishable;
+        return $this->publishable;
     }
 
-    public function setIsPublishable($isPublishable)
+    public function setPublishable($publishable)
     {
-        $this->isPublishable = $isPublishable;
+        $this->publishable = $publishable;
     }
 
     public function getPublishStartDate()


### PR DESCRIPTION
follow form layer convention with setter.

fix #70

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes : existing content must be migrated to rename isPublishable property to publishable |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #70 |
| License | MIT |
| Doc PR | - |
