### PR TITLE
remove PublishWorkflowInterface in favor of broken out interfaces

### DIFF
--- a/Document/MenuNode.php
+++ b/Document/MenuNode.php
@@ -3,7 +3,10 @@
 namespace Symfony\Cmf\Bundle\MenuBundle\Document;
 
 use Knp\Menu\NodeInterface;
-use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableWriteInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodWriteInterface;
 
 /**
  * This class represents a menu node for the cmf.
@@ -11,7 +14,11 @@ use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowInterface;
  * @author Uwe Jäger <uwej711@googlemail.com>
  * @author Daniel Leech <daniel@dantleech.com>
  */
-class MenuNode implements NodeInterface, PublishWorkflowInterface
+class MenuNode implements NodeInterface,
+                            PublishableInterface,
+                            PublishableWriteInterface,
+                            PublishTimePeriodInterface,
+                            PublishTimePeriodWriteInterface
 {
     /**
      * Id of this menu node.

--- a/Tests/Unit/Document/MenuNodeTest.php
+++ b/Tests/Unit/Document/MenuNodeTest.php
@@ -73,7 +73,7 @@ class MenuNodeTest extends \PHPUnit_Framework_Testcase
         $this->assertSame($c2, $ret);
     }
 
-    public function testPublishWorkflowInterface()
+    public function testPublishableInterface()
     {
         $startDate = new \DateTime('2013-01-01');
         $endDate = new \DateTime('2013-02-01');
@@ -81,7 +81,7 @@ class MenuNodeTest extends \PHPUnit_Framework_Testcase
         $n = new MenuNode;
 
         $this->assertInstanceOf(
-            'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowInterface', 
+            'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableInterface', 
             $n
         );
 


### PR DESCRIPTION
This is a fix for:

https://github.com/symfony-cmf/CoreBundle/issues/70
