### PR TITLE
[update] Add support for multiple document managers (issue #79)

### DIFF
--- a/Provider/PHPCRMenuProvider.php
+++ b/Provider/PHPCRMenuProvider.php
@@ -4,6 +4,8 @@ namespace Symfony\Cmf\Bundle\MenuBundle\Provider;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ObjectManager;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\NodeInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
@@ -21,11 +23,6 @@ class PHPCRMenuProvider implements MenuProviderInterface
     protected $factory = null;
 
     /**
-     * @var \Doctrine\ODM\PHPCR\DocumentManager
-     */
-    protected $dm;
-
-    /**
      * base for menu ids
      * @var string
      */
@@ -38,22 +35,47 @@ class PHPCRMenuProvider implements MenuProviderInterface
     protected $className;
 
     /**
+     * If this is null, the manager registry will return the default manager.
+     *
+     * @var string|null Name of object manager to use
+     */
+    protected $managerName;
+
+    /**
+     * @var ManagerRegistry
+     */
+    protected $managerRegistry;
+
+    /**
      * @param ContainerInterface $container di container to get request from to
      *      know current request uri
      * @param FactoryInterface $factory the menu factory to create the menu
      *      item with the root document (usually ContentAwareFactory)
-     * @param string $objectManagerName document manager service name to load menu root
-     *      document from
+     * @param ManagerRegistry $managerRegistry manager registry service to use in conjunction
+     *      with the manager name to load the load menu root document
      * @param string $menuRoot root id of the menu
-     * @param string $className the menu document class name. with phpcr-odm
-     *      this can be null
      */
-    public function __construct(ContainerInterface $container, FactoryInterface $factory, $objectManagerName, $menuRoot)
-    {
+    public function __construct(
+        ContainerInterface $container,
+        FactoryInterface $factory,
+        ManagerRegistry $managerRegistry,
+        $menuRoot
+    ) {
         $this->container = $container;
         $this->factory = $factory;
-        $this->dm = $this->container->get('doctrine_phpcr')->getManager($objectManagerName);
+        $this->managerRegistry = $managerRegistry;
         $this->menuRoot = $menuRoot;
+    }
+
+    /**
+     * Set the object manager name to use for this loader. If not set, the
+     * default manager as decided by the manager registry will be used.
+     *
+     * @param string|null $managerName
+     */
+    public function setManagerName($managerName)
+    {
+        $this->managerName = $managerName;
     }
 
     /**
@@ -86,7 +108,7 @@ class PHPCRMenuProvider implements MenuProviderInterface
             throw new \InvalidArgumentException('The menu name may not be empty');
         }
 
-        $menu = $this->dm->find(null, $this->menuRoot . '/' . $name);
+        $menu = $this->getObjectManager()->find(null, $this->menuRoot . '/' . $name);
         if ($menu === null) {
             throw new \InvalidArgumentException(sprintf('The menu "%s" is not defined.', $name));
         }
@@ -114,7 +136,17 @@ class PHPCRMenuProvider implements MenuProviderInterface
      */
     public function has($name, array $options = array())
     {
-        $menu = $this->dm->find(null, $this->menuRoot . '/' . $name);
+        $menu = $this->getObjectManager()->find(null, $this->menuRoot . '/' . $name);
         return $menu instanceof NodeInterface;
+    }
+
+    /**
+     * Get the object manager named $managerName from the registry.
+     *
+     * @return ObjectManager
+     */
+    protected function getObjectManager()
+    {
+        return $this->managerRegistry->getManager($this->managerName);
     }
 }

--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -14,8 +14,9 @@
             <tag name="knp_menu.provider" />
             <argument type="service" id="service_container"/>
             <argument type="service" id="cmf_menu.factory"/>
-            <argument>%cmf_menu.persistence.phpcr.manager_name%</argument>
+            <argument type="service" id="doctrine_phpcr"/>
             <argument>%cmf_menu.persistence.phpcr.menu_basepath%</argument>
+            <call method="setManagerName"><argument>%cmf_menu.persistence.phpcr.manager_name%</argument></call>
         </service>
 
         <service id="cmf_menu.initializer" class="Doctrine\Bundle\PHPCRBundle\Initializer\GenericInitializer">


### PR DESCRIPTION
**Note: this PR is now based off PR #105.**

Initial attempt at addressing issue #79.

Note that I haven't done any new tests yet; all the existing ones pass except for this one, which is the same as in master for me:

```
1) Symfony\Cmf\Bundle\MenuBundle\Tests\WebTest\Admin\MenuNodeAdminTest\MenuAdminTest::testMenuShow
Failed asserting that 404 matches expected 200.

/var/www/symfony-cmf/MenuBundle/Tests/WebTest/Admin/MenuAdminTest.php:37
```

In order to test this, I think we need the test bundle to support multiple document managers in the functional tests. Same goes for RoutingBundle and BlockBundle.
