### PR TITLE
menu label should not be nullable

### DIFF
--- a/Resources/config/doctrine-model/MenuNode.phpcr.xml
+++ b/Resources/config/doctrine-model/MenuNode.phpcr.xml
@@ -14,7 +14,7 @@
 
         <reference-one name="content" property="menuContent"/>
 
-        <field name="label" type="string" translated="true"/>
+        <field name="label" type="string" translated="true" nullable="false"/>
         <field name="uri" type="string" translated="true"/>
         <field name="linkType" type="string"/>
         <field name="publishable" type="boolean"/>

--- a/Resources/config/doctrine-model/MenuNodeBase.phpcr.xml
+++ b/Resources/config/doctrine-model/MenuNodeBase.phpcr.xml
@@ -15,7 +15,7 @@
         <nodename name="name"/>
         <parent-document name="parent"/>
 
-        <field name="label" type="string"/>
+        <field name="label" type="string" nullable="false"/>
         <field name="uri" type="string"/>
         <field name="route" type="string"/>
         <field name="routeAbsolute" type="boolean"/>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

with this change, the sandbox menu behaves correct again. i notice that somewhere we use the phpcr node name as fallback if the label is not defined. but i think it makes more sense to have the label required.

the underlying issue is that a while ago, we broke the attribute translation strategy for nullable fields when a translation locale does not exist at all, as all fields then become null:
https://github.com/doctrine/phpcr-odm/blob/master/lib/Doctrine/ODM/PHPCR/Translation/TranslationStrategy/AttributeTranslationStrategy.php#L94

i will try to find a solution for phpcr-odm, but its a very tricky problem.
