### PR TITLE
renamed MenuNodeCommon to MenuNodeCommonAdmin

### DIFF
--- a/Admin/MenuAdmin.php
+++ b/Admin/MenuAdmin.php
@@ -4,7 +4,7 @@ namespace Symfony\Cmf\Bundle\MenuBundle\Admin;
 
 use Sonata\AdminBundle\Form\FormMapper;
 
-class MenuAdmin extends MenuNodeCommon
+class MenuAdmin extends MenuNodeCommonAdmin
 {
     protected $baseRouteName = 'cmf_menu';
     protected $baseRoutePattern = '/cmf/menu/menu';

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -7,7 +7,7 @@ use Symfony\Cmf\Bundle\MenuBundle\Model\MenuNode;
 use Knp\Menu\ItemInterface as MenuItemInterface;
 use Doctrine\Common\Util\ClassUtils;
 
-class MenuNodeAdmin extends MenuNodeCommon
+class MenuNodeAdmin extends MenuNodeCommonAdmin
 {
     protected $baseRouteName = 'cmf_menu_menunode';
     protected $baseRoutePattern = '/cmf/menu/menunode';

--- a/Admin/MenuNodeCommonAdmin.php
+++ b/Admin/MenuNodeCommonAdmin.php
@@ -12,7 +12,7 @@ use Symfony\Cmf\Bundle\MenuBundle\ContentAwareFactory;
 /**
  * Common base admin for Menu and MenuNode
  */
-class MenuNodeCommon extends Admin
+class MenuNodeCommonAdmin extends Admin
 {
     protected $contentAwareFactory;
     protected $menuRoot;


### PR DESCRIPTION
lucky, renaming this class has about zero impact.

https://github.com/symfony-cmf/MenuBundle/issues/117
