### PR TITLE
renamed MenuNodeCommonAdmin to AbstractMenuNodeAdmin and changed it to abstract

### DIFF
--- a/Admin/AbstractMenuNodeAdmin.php
+++ b/Admin/AbstractMenuNodeAdmin.php
@@ -12,7 +12,7 @@ use Symfony\Cmf\Bundle\MenuBundle\ContentAwareFactory;
 /**
  * Common base admin for Menu and MenuNode
  */
-class MenuNodeCommonAdmin extends Admin
+abstract class AbstractMenuNodeAdmin extends Admin
 {
     protected $contentAwareFactory;
     protected $menuRoot;

--- a/Admin/MenuAdmin.php
+++ b/Admin/MenuAdmin.php
@@ -4,7 +4,7 @@ namespace Symfony\Cmf\Bundle\MenuBundle\Admin;
 
 use Sonata\AdminBundle\Form\FormMapper;
 
-class MenuAdmin extends MenuNodeCommonAdmin
+class MenuAdmin extends AbstractMenuNodeAdmin
 {
     protected $baseRouteName = 'cmf_menu';
     protected $baseRoutePattern = '/cmf/menu/menu';

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -7,7 +7,7 @@ use Symfony\Cmf\Bundle\MenuBundle\Model\MenuNode;
 use Knp\Menu\ItemInterface as MenuItemInterface;
 use Doctrine\Common\Util\ClassUtils;
 
-class MenuNodeAdmin extends MenuNodeCommonAdmin
+class MenuNodeAdmin extends AbstractMenuNodeAdmin
 {
     protected $baseRouteName = 'cmf_menu_menunode';
     protected $baseRoutePattern = '/cmf/menu/menunode';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #117 |
| License | MIT |
| Doc PR | no |

The follow up to https://github.com/symfony-cmf/MenuBundle/commit/1244d76a4f7a92dcef27d3912c56782985880530 as promised
