### PR TITLE
renaming PHPCRMenuProvider to PhpcrMenuProvider

### DIFF
--- a/Provider/PhpcrMenuProvider.php
+++ b/Provider/PhpcrMenuProvider.php
@@ -10,7 +10,7 @@ use Knp\Menu\FactoryInterface;
 use Knp\Menu\NodeInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 
-class PHPCRMenuProvider implements MenuProviderInterface
+class PhpcrMenuProvider implements MenuProviderInterface
 {
     /**
      * @var ContainerInterface

--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="cmf_menu.provider.class">Symfony\Cmf\Bundle\MenuBundle\Provider\PHPCRMenuProvider</parameter>
+        <parameter key="cmf_menu.provider.class">Symfony\Cmf\Bundle\MenuBundle\Provider\PhpcrMenuProvider</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/commit/4b0c4cf7723af2e34b509b8d623231eb6353f560 |

according to CS.
