### PR TITLE
make the PhpcrMenuProvider synchronized instead of using the container

### DIFF
--- a/Provider/PhpcrMenuProvider.php
+++ b/Provider/PhpcrMenuProvider.php
@@ -2,10 +2,10 @@
 
 namespace Symfony\Cmf\Bundle\MenuBundle\Provider;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\HttpFoundation\Request;
+
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\NodeInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
@@ -13,14 +13,14 @@ use Knp\Menu\Provider\MenuProviderInterface;
 class PhpcrMenuProvider implements MenuProviderInterface
 {
     /**
-     * @var ContainerInterface
-     */
-    protected $container;
-
-    /**
      * @var FactoryInterface
      */
     protected $factory = null;
+
+    /**
+     * @var Request
+     */
+    protected $request;
 
     /**
      * base for menu ids
@@ -47,8 +47,6 @@ class PhpcrMenuProvider implements MenuProviderInterface
     protected $managerRegistry;
 
     /**
-     * @param ContainerInterface $container di container to get request from to
-     *      know current request uri
      * @param FactoryInterface $factory the menu factory to create the menu
      *      item with the root document (usually ContentAwareFactory)
      * @param ManagerRegistry $managerRegistry manager registry service to use in conjunction
@@ -56,12 +54,10 @@ class PhpcrMenuProvider implements MenuProviderInterface
      * @param string $menuRoot root id of the menu
      */
     public function __construct(
-        ContainerInterface $container,
         FactoryInterface $factory,
         ManagerRegistry $managerRegistry,
         $menuRoot
     ) {
-        $this->container = $container;
         $this->factory = $factory;
         $this->managerRegistry = $managerRegistry;
         $this->menuRoot = $menuRoot;
@@ -95,6 +91,16 @@ class PhpcrMenuProvider implements MenuProviderInterface
     }
 
     /**
+     * Set the request, used for the cmf_request_aware tag.
+     *
+     * @param Request $request
+     */
+    public function setRequest(Request $request = null)
+    {
+        $this->request = $request;
+    }
+
+    /**
      * Get a menu node by name
      *
      * @param  string                    $name
@@ -117,14 +123,14 @@ class PhpcrMenuProvider implements MenuProviderInterface
             throw new \InvalidArgumentException("Menu at '$name' is not a valid menu node");
         }
 
-        $menuNode = $this->factory->createFromNode($menu);
-        if (empty($menuNode)) {
+        $menuItem = $this->factory->createFromNode($menu);
+        if (empty($menuItem)) {
             throw new \InvalidArgumentException("Menu at '$name' is misconfigured (f.e. the route might be incorrect) and could therefore not be instanciated");
         }
 
-        $menuNode->setCurrentUri($this->container->get('request')->getRequestUri());
+        $menuItem->setCurrentUri($this->request->getRequestUri());
 
-        return $menuNode;
+        return $menuItem;
     }
 
     /**

--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -12,18 +12,18 @@
 
         <service id="cmf_menu.provider" class="%cmf_menu.provider.class%">
             <tag name="knp_menu.provider" />
-            <argument type="service" id="service_container"/>
             <argument type="service" id="cmf_menu.factory"/>
             <argument type="service" id="doctrine_phpcr"/>
             <argument>%cmf_menu.persistence.phpcr.menu_basepath%</argument>
             <call method="setManagerName"><argument>%cmf_menu.persistence.phpcr.manager_name%</argument></call>
+            <tag name="cmf_request_aware"/>
         </service>
 
         <service id="cmf_menu.initializer" class="Doctrine\Bundle\PHPCRBundle\Initializer\GenericInitializer">
             <argument type="collection">
                 <argument>%cmf_menu.persistence.phpcr.menu_basepath%</argument>
             </argument>
-            <tag name="doctrine_phpcr.initializer" />
+            <tag name="doctrine_phpcr.initializer"/>
         </service>
 
     </services>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | see travis |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

we should avoid unnecessary dependencies on the DI container.
