### PR TITLE
a root menu document can not be added anywhere in the tree, only at the root

### DIFF
--- a/Admin/AbstractMenuNodeAdmin.php
+++ b/Admin/AbstractMenuNodeAdmin.php
@@ -34,15 +34,13 @@ abstract class AbstractMenuNodeAdmin extends Admin
         return $this->hasSubject() && null !== $this->getSubject()->getId();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
             ->with('form.group_general')
-                ->add(
-                    'parent',
-                    'doctrine_phpcr_odm_tree',
-                    array('root_node' => $this->menuRoot, 'choice_list' => array(), 'select_root_node' => true)
-                )
                 ->add('name', 'text',
                     $this->isSubjectNotNew() ? array(
                         'attr' => array('readonly' => 'readonly')

--- a/Admin/MenuAdmin.php
+++ b/Admin/MenuAdmin.php
@@ -3,12 +3,16 @@
 namespace Symfony\Cmf\Bundle\MenuBundle\Admin;
 
 use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\Menu;
 
 class MenuAdmin extends AbstractMenuNodeAdmin
 {
     protected $baseRouteName = 'cmf_menu';
     protected $baseRoutePattern = '/cmf/menu/menu';
 
+    /**
+     * {@inheritDoc}
+     */
     protected function configureFormFields(FormMapper $formMapper)
     {
         parent::configureFormFields($formMapper);
@@ -29,5 +33,14 @@ class MenuAdmin extends AbstractMenuNodeAdmin
                 ->end()
             ;
         }
+    }
+
+    public function getNewInstance()
+    {
+        /** @var $new Menu */
+        $new = parent::getNewInstance();
+        $new->setParent($this->getModelManager()->find(null, $this->menuRoot));
+
+        return $new;
     }
 }

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Cmf\Bundle\MenuBundle\Admin;
 
+use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
 use Symfony\Cmf\Bundle\MenuBundle\Model\MenuNode;
 use Knp\Menu\ItemInterface as MenuItemInterface;
@@ -11,6 +12,23 @@ class MenuNodeAdmin extends AbstractMenuNodeAdmin
 {
     protected $baseRouteName = 'cmf_menu_menunode';
     protected $baseRoutePattern = '/cmf/menu/menunode';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->with('form.group_general')
+                ->add(
+                    'parent',
+                    'doctrine_phpcr_odm_tree',
+                    array('root_node' => $this->menuRoot, 'choice_list' => array(), 'select_root_node' => true)
+                )
+            ->end()
+        ;
+        parent::configureFormFields($formMapper);
+    }
 
     /**
      * {@inheritDoc}

--- a/Tests/WebTest/Admin/MenuAdminTest.php
+++ b/Tests/WebTest/Admin/MenuAdminTest.php
@@ -50,7 +50,6 @@ class MenuAdminTest extends BaseTestCase
         $actionUrl = $node->getAttribute('action');
         $uniqId = substr(strchr($actionUrl, '='), 1);
 
-        $form[$uniqId.'[parent]'] = '/test/menus';
         $form[$uniqId.'[name]'] = 'foo-test';
         $form[$uniqId.'[label]'] = 'Foo Test';
 

--- a/Tests/WebTest/Admin/MenuNodeAdminTest.php
+++ b/Tests/WebTest/Admin/MenuNodeAdminTest.php
@@ -16,7 +16,7 @@ class MenuNodeAdminTest extends BaseTestCase
 
     public function testEdit()
     {
-        $crawler = $this->client->request('GET', '/admin/cmf/menu/menunode/test/menus/test-menu/item-1/edit');
+        $this->client->request('GET', '/admin/cmf/menu/menunode/test/menus/test-menu/item-1/edit');
         $res = $this->client->getResponse();
         $this->assertEquals(200, $res->getStatusCode());
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | see travis |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

as the menu document is supposed to be a menu root, no need to select the parent, it is automatically defined.
