### PR TITLE
remove unneeded hardcoded route name from admin

### DIFF
--- a/Admin/MenuAdmin.php
+++ b/Admin/MenuAdmin.php
@@ -17,8 +17,6 @@ use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\Menu;
 
 class MenuAdmin extends AbstractMenuNodeAdmin
 {
-    protected $baseRouteName = 'cmf_menu';
-    protected $baseRoutePattern = '/cmf/menu/menu';
 
     /**
      * {@inheritDoc}

--- a/Admin/MenuNodeAdmin.php
+++ b/Admin/MenuNodeAdmin.php
@@ -21,8 +21,6 @@ use Doctrine\Common\Util\ClassUtils;
 
 class MenuNodeAdmin extends AbstractMenuNodeAdmin
 {
-    protected $baseRouteName = 'cmf_menu_menunode';
-    protected $baseRoutePattern = '/cmf/menu/menunode';
     protected $recursiveBreadcrumbs = true;
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

These assignments are no longer needed. If we have them, an admin extending this class must overwrite the fields.
