### PR TITLE
Update persistence-phpcr.xml

### DIFF
--- a/Resources/config/persistence-phpcr.xml
+++ b/Resources/config/persistence-phpcr.xml
@@ -21,7 +21,7 @@
         </service>
 
         <service id="cmf_menu.initializer" class="Doctrine\Bundle\PHPCRBundle\Initializer\GenericInitializer">
-            <argument>cmf_menu.initializer</argument>
+            <argument>CmfMenuBundle</argument>
             <argument type="collection">
                 <argument>%cmf_menu.persistence.phpcr.menu_basepath%</argument>
             </argument>


### PR DESCRIPTION
Since doctrine/DoctrinePHPCRBundle@013766896eec6e1119fc8c453e266a18866e2511 the `GenericInitializer` requires a name as the first parameter
