### PR TITLE
catch the right exception while prefetching

### DIFF
--- a/Provider/PhpcrMenuProvider.php
+++ b/Provider/PhpcrMenuProvider.php
@@ -15,10 +15,11 @@ namespace Symfony\Cmf\Bundle\MenuBundle\Provider;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Symfony\Component\HttpFoundation\Request;
-use PHPCR\ItemNotFoundException;
+use PHPCR\PathNotFoundException;
 use PHPCR\Util\PathHelper;
 use Jackalope\Session;
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Knp\Menu\NodeInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 
@@ -230,7 +231,7 @@ class PhpcrMenuProvider implements MenuProviderInterface
                 } else {
                     $session->getNode($path, $this->getPrefetch());
                 }
-            } catch(ItemNotFoundException $e) {
+            } catch(PathNotFoundException $e) {
                 if ($throw) {
                     throw new \InvalidArgumentException(sprintf('The menu root "%s" does not exist.', $this->getMenuRoot()));
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

we tried to catch the wrong exception. this shows for example when having 2 menu providers with the simple cms bundle.
