### PR TITLE
Require at least 1.1.0 of core bundle for ChildInterface.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "doctrine/phpcr-bundle": "1.1.*",
         "doctrine/phpcr-odm": "1.1.*",
         "knplabs/knp-menu-bundle": "1.1.*",
-        "symfony-cmf/core-bundle": ">=1.0.0,<1.2-dev"
+        "symfony-cmf/core-bundle": ">=1.1.0,<1.2-dev"
     },
     "require-dev": {
         "symfony-cmf/routing-bundle": "1.2.*",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | ?? (We'll see) |
