### PR TITLE
fix test setup, added php 5.6 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
     - hhvm
 
 env:
@@ -12,7 +13,6 @@ env:
 matrix:
   allow_failures:
     - env: SYMFONY_VERSION=dev-master
-    - php: hhvm
   include:
     - php: 5.5
       env: SYMFONY_VERSION=2.3.*

--- a/Admin/AbstractMenuNodeAdmin.php
+++ b/Admin/AbstractMenuNodeAdmin.php
@@ -24,8 +24,24 @@ use Symfony\Cmf\Bundle\MenuBundle\ContentAwareFactory;
  */
 abstract class AbstractMenuNodeAdmin extends Admin
 {
+    /**
+     * @var ContentAwareFactory
+     */
     protected $contentAwareFactory;
+
+    /**
+     * @var string
+     */
+    protected $contentRoot;
+
+    /**
+     * @var string
+     */
     protected $menuRoot;
+
+    /**
+     * @var string
+     */
     protected $translationDomain = 'CmfMenuBundle';
 
     protected function configureListFields(ListMapper $listMapper)
@@ -83,7 +99,7 @@ abstract class AbstractMenuNodeAdmin extends Admin
         }
     }
 
-    protected function configureShowField(ShowMapper $showMapper)
+    protected function configureShowFields(ShowMapper $showMapper)
     {
         $showMapper
             ->add('id', 'text')

--- a/Tests/Resources/app/config/config.php
+++ b/Tests/Resources/app/config/config.php
@@ -1,5 +1,6 @@
 <?php
 
+$container->setParameter('cmf_testing.bundle_fqn', 'Symfony\Cmf\Bundle\MenuBundle');
 $loader->import(CMF_TEST_CONFIG_DIR.'/default.php');
 $loader->import(CMF_TEST_CONFIG_DIR.'/phpcr_odm.php');
 $loader->import(CMF_TEST_CONFIG_DIR.'/sonata_admin.php');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

It seems like there is no output for "show" anymore when using SontaAdminBundle 2.3:
http://cmf.liip.ch/en/admin/cmf/menu/menu/cms/menu/main/show

@rande any tip for how to fix this?
