### PR TITLE
fix admin show view

### DIFF
--- a/Admin/AbstractMenuNodeAdmin.php
+++ b/Admin/AbstractMenuNodeAdmin.php
@@ -102,11 +102,11 @@ abstract class AbstractMenuNodeAdmin extends Admin
     protected function configureShowFields(ShowMapper $showMapper)
     {
         $showMapper
-            ->add('id', 'text')
-            ->add('name', 'text')
-            ->add('label', 'text')
-            ->add('uri', 'text')
-            ->add('content', 'text')
+            ->add('id')
+            ->add('name')
+            ->add('label')
+            ->add('uri')
+            ->add('content', null, array('associated_property' => 'title'))
         ;
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #209 |
| License | MIT |
| Doc PR |  |

sonata doctrine phpcr admin did not properly handle relations in show mode. but additionally, this admin was trying to confuse the show mapper.

this change will only help together with
https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/307 - but we can merge, things won't get worse than before.
