### PR TITLE
Add functional tests for admin deletion

### DIFF
--- a/Tests/WebTest/Admin/MenuAdminTest.php
+++ b/Tests/WebTest/Admin/MenuAdminTest.php
@@ -21,7 +21,7 @@ class MenuAdminTest extends BaseTestCase
             'Symfony\Cmf\Bundle\MenuBundle\Tests\Resources\DataFixtures\PHPCR\LoadMenuData',
         ));
         $this->client = $this->createClient();
-        $this->documentManager = $this->db('PHPCR')->getOm();
+        $this->documentManager = $this->client->getContainer()->get('doctrine_phpcr.odm.document_manager');
     }
 
     public function testMenuList()
@@ -84,7 +84,8 @@ class MenuAdminTest extends BaseTestCase
         // If we have a 302 redirect, then all is well
         $this->assertEquals(302, $res->getStatusCode());
 
-        $this->setExpectedException('PHPCR\InvalidItemStateException');
-        $menuItem = $this->documentManager->find(null, '/test/menus/test-menu');
+        $documentManager = $this->client->getContainer()->get('doctrine_phpcr.odm.document_manager');
+        $menu = $documentManager->find(null, '/test/menus/test-menu');
+        $this->assertNull($menu);
     }
 }

--- a/Tests/WebTest/Admin/MenuNodeAdminTest.php
+++ b/Tests/WebTest/Admin/MenuNodeAdminTest.php
@@ -21,7 +21,6 @@ class MenuNodeAdminTest extends BaseTestCase
             'Symfony\Cmf\Bundle\MenuBundle\Tests\Resources\DataFixtures\PHPCR\LoadMenuData',
         ));
         $this->client = $this->createClient();
-        $this->documentManager = $this->db('PHPCR')->getOm();
     }
 
     public function testEdit()
@@ -45,7 +44,8 @@ class MenuNodeAdminTest extends BaseTestCase
         // If we have a 302 redirect, then all is well
         $this->assertEquals(302, $res->getStatusCode());
 
-        $this->setExpectedException('PHPCR\InvalidItemStateException');
-        $menuItem = $this->documentManager->find(null, '/test/menus/test-menu/item-2');
+        $documentManager = $this->client->getContainer()->get('doctrine_phpcr.odm.document_manager');
+        $menuItem = $documentManager->find(null, '/test/menus/test-menu/item-2');
+        $this->assertNull($menuItem);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

I also wanted to confirm that its correct that calling find(null, '/deleted/path') should throw a PHPCR exception. We found this in writing our own tests and it seems like it is not totally consistent with the way the ObjectManager works in the ORM and we expected it would just return null.
