### PR TITLE
Add initial Symfony 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -15,18 +13,17 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
-  global: SYMFONY_DEPRECATIONS_HELPER=533
+  matrix: SYMFONY_VERSION=2.8.*
+  global: SYMFONY_DEPRECATIONS_HELPER=321
 
 matrix:
   include:
+    - php: 7.0
+      env: DEPS=dev SYMFONY_VERSION=3.1.*
+    - php: 5.5
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 5.6
-      env: DEPS=dev SYMFONY_VERSION=2.8.*
-    - php: 5.3
-      env: SYMFONY_VERSION="^2.3.4" COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
+      env: DEPS=dev COMPOSER_FLAGS="--prefer-stable" SYMFONY_VERSION=3.0.*
   fast_finish: true
 
 before_install:

--- a/Admin/AbstractMenuNodeAdmin.php
+++ b/Admin/AbstractMenuNodeAdmin.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Cmf\Bundle\MenuBundle\Model\MenuNodeBase;
 
 /**
@@ -52,8 +53,8 @@ abstract class AbstractMenuNodeAdmin extends Admin
     {
         $formMapper
             ->with('form.group_general')
-                ->add('name', 'text')
-                ->add('label', 'text')
+                ->add('name', TextType::class)
+                ->add('label', TextType::class)
             ->end()
         ;
     }

--- a/Admin/MenuAdmin.php
+++ b/Admin/MenuAdmin.php
@@ -12,6 +12,7 @@
 namespace Symfony\Cmf\Bundle\MenuBundle\Admin;
 
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeManagerType;
 use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\Menu;
 
 class MenuAdmin extends AbstractMenuNodeAdmin
@@ -29,7 +30,7 @@ class MenuAdmin extends AbstractMenuNodeAdmin
         if (!$isNew) {
             $formMapper
                 ->with('form.group_items', array())
-                    ->add('children', 'doctrine_phpcr_odm_tree_manager', array(
+                    ->add('children', TreeManagerType::class, array(
                         'root' => $this->menuRoot,
                         'edit_in_overlay' => false,
                         'create_in_overlay' => false,

--- a/PublishWorkflow/CreateMenuItemFromNodeListener.php
+++ b/PublishWorkflow/CreateMenuItemFromNodeListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\MenuBundle\PublishWorkflow;
 
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Cmf\Bundle\MenuBundle\Event\CreateMenuItemFromNodeEvent;
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
 
@@ -36,10 +36,10 @@ class CreateMenuItemFromNodeListener
     private $publishWorkflowPermission;
 
     /**
-     * @param SecurityContextInterface $publishWorkflowChecker The publish workflow checker.
-     * @param string                   $attribute              The permission to check.
+     * @param AuthorizationCheckerInterface $publishWorkflowChecker The publish workflow checker.
+     * @param string                        $attribute              The permission to check.
      */
-    public function __construct(SecurityContextInterface $publishWorkflowChecker, $attribute = PublishWorkflowChecker::VIEW_ATTRIBUTE)
+    public function __construct(AuthorizationCheckerInterface $publishWorkflowChecker, $attribute = PublishWorkflowChecker::VIEW_ATTRIBUTE)
     {
         $this->publishWorkflowChecker = $publishWorkflowChecker;
         $this->publishWorkflowPermission = $attribute;

--- a/Tests/Resources/app/AppKernel.php
+++ b/Tests/Resources/app/AppKernel.php
@@ -27,6 +27,13 @@ class AppKernel extends TestKernel
             new \Symfony\Cmf\Bundle\CoreBundle\CmfCoreBundle(),
             new \Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle(),
         ));
+
+        if (class_exists('Symfony\Cmf\Bundle\ResourceRestBundle\CmfResourceRestBundle')) {
+            $this->addBundles(array(
+                new \Symfony\Cmf\Bundle\ResourceBundle\CmfResourceBundle(),
+                new \Symfony\Cmf\Bundle\ResourceRestBundle\CmfResourceRestBundle(),
+            ));
+        }
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)

--- a/Tests/Resources/app/config/config.php
+++ b/Tests/Resources/app/config/config.php
@@ -10,6 +10,11 @@
  */
 
 $container->setParameter('cmf_testing.bundle_fqn', 'Symfony\Cmf\Bundle\MenuBundle');
+
+$container->loadFromExtension('framework', array(
+    'serializer' => true,
+));
+
 $loader->import(CMF_TEST_CONFIG_DIR.'/default.php');
 $loader->import(CMF_TEST_CONFIG_DIR.'/phpcr_odm.php');
 $loader->import(CMF_TEST_CONFIG_DIR.'/sonata_admin.php');

--- a/Tests/Resources/app/config/routing.php
+++ b/Tests/Resources/app/config/routing.php
@@ -12,11 +12,14 @@
 use Symfony\Component\Routing\RouteCollection;
 
 $collection = new RouteCollection();
-$collection->addCollection(
-    $loader->import(CMF_TEST_CONFIG_DIR.'/routing/sonata_routing.yml')
-);
-$collection->addCollection(
-    $loader->import(__DIR__.'/routing/test.yml')
-);
+
+$treeBrowserVersion = '1.x';
+if (class_exists('Symfony\Cmf\Bundle\ResourceRestBundle\CmfResourceRestBundle')) {
+    $treeBrowserVersion = '2.x';
+}
+
+$collection->addCollection($loader->import(__DIR__.'/routing/sonata.yml'));
+$collection->addCollection($loader->import(__DIR__.'/routing/tree_browser_'.$treeBrowserVersion.'.yml'));
+$collection->addCollection($loader->import(__DIR__.'/routing/test.yml'));
 
 return $collection;

--- a/Tests/Resources/app/config/routing/sonata.yml
+++ b/Tests/Resources/app/config/routing/sonata.yml
@@ -1,0 +1,10 @@
+admin:
+    resource: '@SonataAdminBundle/Resources/config/routing/sonata_admin.xml'
+    prefix: /admin
+
+sonata_admin:
+    resource: .
+    type: sonata_admin
+    prefix: /admin
+    requirements:
+        id:  .+

--- a/Tests/Resources/app/config/routing/tree_browser_1.x.yml
+++ b/Tests/Resources/app/config/routing/tree_browser_1.x.yml
@@ -1,0 +1,6 @@
+cmf_tree:
+    resource: .
+    type: 'cmf_tree'
+
+fos_js_routing:
+    resource: '@FOSJsRoutingBundle/Resources/config/routing/routing.xml'

--- a/Tests/Resources/app/config/routing/tree_browser_2.x.yml
+++ b/Tests/Resources/app/config/routing/tree_browser_2.x.yml
@@ -1,0 +1,2 @@
+_cmf_resource:
+    resource: '@CmfResourceRestBundle/Resources/config/routing.yml'

--- a/composer.json
+++ b/composer.json
@@ -12,24 +12,23 @@
         }
     ],
     "require": {
-        "php": "^5.3.9|^7.0",
-        "symfony/framework-bundle": "^2.3",
-        "symfony-cmf/core-bundle": "^1.1.0",
+        "php": "^5.5.9|^7.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony-cmf/core-bundle": "^2.0@dev",
         "doctrine/phpcr-bundle": "^1.1",
-        "doctrine/phpcr-odm": "^1.1",
+        "doctrine/phpcr-odm": "^1.3",
         "knplabs/knp-menu-bundle": "^2.0.0",
         "knplabs/knp-menu": "^2.0.0"
     },
     "require-dev": {
-        "symfony/monolog-bundle": "^2.3",
-        "symfony-cmf/routing-bundle": "^1.2.0",
+        "symfony/monolog-bundle": "^2.3|^3.0",
+        "symfony-cmf/routing-bundle": "^1.2.0|^2.0",
         "symfony-cmf/testing": "^1.3",
-        "symfony-cmf/tree-browser-bundle": "^1.0.0",
-        "doctrine/phpcr-odm": "^1.3",
-        "twig/twig": "^1.18",
-        "sonata-project/doctrine-phpcr-admin-bundle": "^1.1",
-        "sonata-project/block-bundle": "^2.2.8",
-        "sonata-project/core-bundle": "^2.2.3"
+        "twig/twig": "^1.18|^2.0",
+        "sonata-project/doctrine-phpcr-admin-bundle": "^1.2.4|^2.0",
+        "sonata-project/admin-bundle": "^2.3.7|^3.0",
+        "sonata-project/block-bundle": "^2.2.8|^3.0",
+        "sonata-project/core-bundle": "^2.2.5|^3.0"
     },
     "suggest": {
         "sonata-project/doctrine-phpcr-admin-bundle": "if you want to have editing capabilities (^1.1)",


### PR DESCRIPTION
It's initial because this only makes the tests pass. I have not yet tested it in a Symfony 3 application. After the major bundles have Symfony 3 support, we need to get the sandbox working on Symfony 3 to properly test the Symfony 3 support.

These PRs have to be merged before this one:

 * [x] https://github.com/symfony-cmf/routing-bundle/pull/347
 * [x] https://github.com/symfony-cmf/core-bundle/pull/181
 * [x] https://github.com/sonata-project/SonataAdminBundle#3709
 * [x] https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/367