### PR TITLE
Made Composer version resolving easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
+  matrix: SYMFONY_VERSION=2.8.*
   global: SYMFONY_DEPRECATIONS_HELPER=533
 
 matrix:


### PR DESCRIPTION
This solves Travis failures on PHP 5.5 and 5.6