### PR TITLE
Restrict children type of Menu and MenuNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* **2017-02-09**: [BC BREAK] Added child restrictions to the `Menu` and `MenuNode` documents.
+  See the UPGRADE guide for detailed information.
+
 2.1.0-RC1
 ---------
 

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -67,3 +67,9 @@
                            - cmf_sonata_admin_integration.menu.menu_admin
                            - cmf_sonata_admin_integration.menu.node_admin
    ```
+
+# Doctrine PHPCR ODM
+
+ * Only `MenuNode` documents are allowed as children of the `Menu` and
+   `MenuNode` documents. This behaviour can be changed by overriding the
+   `child-class` setting of the PHPCR ODM mapping.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/framework-bundle": "^2.8|^3.0",
         "symfony-cmf/core-bundle": "^2.0",
         "doctrine/phpcr-bundle": "^1.1",
-        "doctrine/phpcr-odm": "^1.4|^2.0",
+        "doctrine/phpcr-odm": "^1.4.2",
         "knplabs/knp-menu-bundle": "^2.0.0",
         "knplabs/knp-menu": "^2.0.0"
     },

--- a/src/Resources/config/doctrine-phpcr/Menu.phpcr.xml
+++ b/src/Resources/config/doctrine-phpcr/Menu.phpcr.xml
@@ -9,6 +9,7 @@
         name="Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\Menu"
         referenceable="true"
         >
+        <child-class name="Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode"/>
     </document>
 
 </doctrine-mapping>

--- a/src/Resources/config/doctrine-phpcr/MenuNode.phpcr.xml
+++ b/src/Resources/config/doctrine-phpcr/MenuNode.phpcr.xml
@@ -9,6 +9,7 @@
         name="Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode"
         referenceable="true"
         >
+        <child-class name="Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode"/>
     </document>
 
 </doctrine-mapping>

--- a/tests/Functional/Doctrine/Phpcr/MenuNodeTest.php
+++ b/tests/Functional/Doctrine/Phpcr/MenuNodeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\MenuBundle\Tests\Functional\Doctrine\Phpcr;
 
+use Doctrine\ODM\PHPCR\Document\Generic;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode;
 use Symfony\Cmf\Bundle\MenuBundle\Tests\Resources\Document\Content;
@@ -29,7 +30,7 @@ class MenuNodeTest extends BaseTestCase
      */
     private $child1;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->db('PHPCR')->createTestNode();
 
@@ -156,5 +157,24 @@ class MenuNodeTest extends BaseTestCase
         $this->dm->clear();
         $menuNode = $this->dm->find(null, '/test/test-node');
         $this->assertCount(0, $menuNode->getChildren());
+    }
+
+    /**
+     * @expectedException \Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
+     * @expectedExceptionMessage Allowed child classes "Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode"
+     */
+    public function testPersistInvalidChild()
+    {
+        $menuNode = new MenuNode();
+        $menuNode->setName('menu-node');
+        $menuNode->setParentDocument($this->rootDocument);
+        $this->dm->persist($menuNode);
+
+        $generic = new Generic();
+        $generic->setParentDocument($menuNode);
+        $generic->setNodename('invalid');
+        $this->dm->persist($generic);
+
+        $this->dm->flush();
     }
 }

--- a/tests/Functional/Doctrine/Phpcr/MenuTest.php
+++ b/tests/Functional/Doctrine/Phpcr/MenuTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\MenuBundle\Tests\Functional\Doctrine\Phpcr;
+
+use Doctrine\ODM\PHPCR\Document\Generic;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\Menu;
+use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode;
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+
+class MenuTest extends BaseTestCase
+{
+    /**
+     * @var DocumentManager
+     */
+    private $dm;
+    private $rootDocument;
+
+    protected function setUp()
+    {
+        $this->db('PHPCR')->createTestNode();
+
+        $this->dm = $this->db('PHPCR')->getOm();
+        $this->rootDocument = $this->dm->find(null, '/test');
+    }
+
+    public function testPersist()
+    {
+        $menu = new Menu();
+        $menu->setPosition($this->rootDocument, 'main');
+        $this->dm->persist($menu);
+
+        $menuNode = new MenuNode();
+        $menuNode->setName('home');
+        $menu->addChild($menuNode);
+        $this->dm->persist($menuNode);
+
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $menu = $this->dm->find(null, '/test/main');
+
+        $this->assertNotNull($menu);
+        $this->assertEquals('main', $menu->getName());
+
+        $children = $menu->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertEquals('home', $children[0]->getName());
+    }
+
+    /**
+     * @dataProvider getInvalidChildren
+     * @expectedException \Doctrine\ODM\PHPCR\Exception\OutOfBoundsException
+     */
+    public function testPersistInvalidChild($invalidChild)
+    {
+        $menu = new Menu();
+        $menu->setPosition($this->rootDocument, 'main');
+        $this->dm->persist($menu);
+
+        $invalidChild->setParentDocument($menu);
+        $this->dm->persist($invalidChild);
+
+        $this->dm->flush();
+    }
+
+    public function getInvalidChildren()
+    {
+        return [
+            [(new Menu())->setName('invalid')],
+            [(new Generic())->setNodename('invalid')],
+        ];
+    }
+}


### PR DESCRIPTION
/fixes #286 

Build if failing because PHPCR ODM 1.4.1 is not yet released.