### PR TITLE
Use RequestStack in voters

### DIFF
--- a/src/Resources/config/voters.xml
+++ b/src/Resources/config/voters.xml
@@ -7,13 +7,14 @@
     <services>
 
         <service id="cmf_menu.current_item_voter.uri_prefix" class="Symfony\Cmf\Bundle\MenuBundle\Voter\UriPrefixVoter">
-            <tag name="knp_menu.voter" request="true"/>
+            <argument type="service" id="request_stack"/>
+            <tag name="knp_menu.voter"/>
         </service>
 
         <service id="cmf_menu.current_item_voter.content_identity" class="Symfony\Cmf\Bundle\MenuBundle\Voter\RequestContentIdentityVoter">
             <argument>%cmf_menu.content_key%</argument>
-
-            <tag name="knp_menu.voter" request="true"/>
+            <argument type="service" id="request_stack"/>
+            <tag name="knp_menu.voter"/>
         </service>
 
     </services>

--- a/src/Voter/RequestParentContentIdentityVoter.php
+++ b/src/Voter/RequestParentContentIdentityVoter.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\MenuBundle\Voter;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * A variant of the RequestContentIdentityVoter that checks if the request
@@ -38,45 +39,74 @@ class RequestParentContentIdentityVoter implements VoterInterface
     private $childClass;
 
     /**
+     * @var RequestStack|null
+     */
+    private $requestStack;
+
+    /**
      * @var Request|null
      */
     private $request;
 
     /**
-     * @param string $requestKey The key to look up the content in the request
-     *                           attributes
-     * @param string $childClass Fully qualified class name of the model class
-     *                           the content in the request must have to
-     *                           attempt calling getParentDocument on it
+     * @param string            $requestKey   The key to look up the content in the request
+     *                                        attributes
+     * @param string            $childClass   Fully qualified class name of the model class
+     *                                        the content in the request must have to
+     *                                        attempt calling getParentDocument on it
+     * @param RequestStack|null $requestStack
      */
-    public function __construct($requestKey, $childClass)
+    public function __construct($requestKey, $childClass, RequestStack $requestStack = null)
     {
         $this->requestKey = $requestKey;
         $this->childClass = $childClass;
+        $this->requestStack = $requestStack;
     }
 
+    /**
+     * @deprecated since version 2.2. Pass a RequestStack to the constructor instead.
+     */
     public function setRequest(Request $request = null)
     {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated since version 2.2.
+                Pass a Symfony\Component\HttpFoundation\RequestStack
+                in the constructor instead.',
+                __METHOD__),
+            E_USER_DEPRECATED
+        );
+
         $this->request = $request;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function matchItem(ItemInterface $item = null)
+    public function matchItem(ItemInterface $item)
     {
-        if (!$this->request) {
+        $request = $this->getRequest();
+        if (!$request) {
             return;
         }
 
         $content = $item->getExtra('content');
 
         if (null !== $content
-            && $this->request->attributes->has($this->requestKey)
-            && $this->request->attributes->get($this->requestKey) instanceof $this->childClass
-            && $this->request->attributes->get($this->requestKey)->getParentDocument() === $content
+            && $request->attributes->has($this->requestKey)
+            && $request->attributes->get($this->requestKey) instanceof $this->childClass
+            && $request->attributes->get($this->requestKey)->getParentDocument() === $content
         ) {
             return true;
         }
+    }
+
+    private function getRequest()
+    {
+        if ($this->requestStack) {
+            return $this->requestStack->getMasterRequest();
+        }
+
+        return $this->request;
     }
 }

--- a/src/Voter/UriPrefixVoter.php
+++ b/src/Voter/UriPrefixVoter.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\MenuBundle\Voter;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -31,12 +32,36 @@ use Symfony\Component\Routing\Route;
 class UriPrefixVoter implements VoterInterface
 {
     /**
+     * @var RequestStack
+     */
+     private $requestStack;
+ 
+    /**
      * @var Request|null
      */
     private $request;
 
+    public function __construct(RequestStack $requestStack = null)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @deprecated since version 3.x. Pass a RequestStack to the constructor instead.
+     *
+     * @return $this
+     */
     public function setRequest(Request $request = null)
     {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated since version 3.x.
+                Pass a Symfony\Component\HttpFoundation\RequestStack
+                in the constructor instead.',
+            __METHOD__),
+            E_USER_DEPRECATED
+        );
+
         $this->request = $request;
     }
 
@@ -51,6 +76,11 @@ class UriPrefixVoter implements VoterInterface
 
         $content = $item->getExtra('content');
 
+        $request = $this->request;
+        if (null !== $this->requestStack) {
+            $request = $this->requestStack->getMasterRequest();
+        }
+/* no idea what to do here ... & beyond */        
         if ($content instanceof Route && $content->hasOption('currentUriPrefix')) {
             $currentUriPrefix = $content->getOption('currentUriPrefix');
             $currentUriPrefix = str_replace('{_locale}', $this->request->getLocale(), $currentUriPrefix);

--- a/tests/Unit/Voter/LegacyRequestContentIdentityVoterTest.php
+++ b/tests/Unit/Voter/LegacyRequestContentIdentityVoterTest.php
@@ -13,22 +13,24 @@ namespace Symfony\Cmf\Bundle\MenuBundle\Tests\Unit\Voter;
 
 use Symfony\Cmf\Bundle\MenuBundle\Voter\RequestContentIdentityVoter;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
-class RequestContentIdentityVoterTest extends RequestContentIdentityVoterTestCase
+/**
+ * @legacy
+ */
+class LegacyRequestContentIdentityVoterTest extends RequestContentIdentityVoterTestCase
 {
     protected function buildVoter(Request $request)
     {
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $voter = new RequestContentIdentityVoter('_content');
+        $voter->setRequest($request);
 
-        return new RequestContentIdentityVoter('_content', $requestStack);
+        return $voter;
     }
 
     public function testSkipsWhenNoRequestIsAvailable()
     {
-        $voter = new RequestContentIdentityVoter('_content', new RequestStack());
+        $this->voter->setRequest(null);
 
-        $this->assertNull($voter->matchItem($this->createItem()));
+        $this->assertNull($this->voter->matchItem($this->createItem()));
     }
 }

--- a/tests/Unit/Voter/RequestContentIdentityVoterTestCase.php
+++ b/tests/Unit/Voter/RequestContentIdentityVoterTestCase.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\MenuBundle\Tests\Unit\Voter;
+
+use Knp\Menu\ItemInterface;
+use Symfony\Cmf\Bundle\MenuBundle\Voter\RequestContentIdentityVoter;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+abstract class RequestContentIdentityVoterTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RequestContentIdentityVoter
+     */
+    protected $voter;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    protected function setUp()
+    {
+        $this->request = $this->prophesize(Request::class);
+
+        $this->voter = $this->buildVoter($this->request->reveal());
+    }
+
+    abstract protected function buildVoter(Request $request);
+
+    abstract public function testSkipsWhenNoRequestIsAvailable();
+
+    public function testSkipsWhenNoContentIsAvailable()
+    {
+        $this->assertNull($this->voter->matchItem($this->createItem()));
+    }
+
+    public function testSkipsWhenNoContentAttributeWasDefined()
+    {
+        $attributes = $this->prophesize(ParameterBag::class);
+        $attributes->has('_content')->willReturn(false);
+        $this->request->attributes = $attributes;
+
+        $this->assertNull($this->voter->matchItem($this->createItem(new \stdClass())));
+    }
+
+    public function testMatchesWhenContentIsEqualToCurrentContent()
+    {
+        $content = new \stdClass();
+
+        $attributes = $this->prophesize(ParameterBag::class);
+        $attributes->has('_content')->willReturn(true);
+        $attributes->get('_content')->willReturn($content);
+        $this->request->attributes = $attributes;
+
+        $this->assertTrue($this->voter->matchItem($this->createItem($content)));
+    }
+
+    public function testSkipsWhenContentIsNotEqual()
+    {
+        $attributes = $this->prophesize(ParameterBag::class);
+        $attributes->has('_content')->willReturn(true);
+        $attributes->get('_content')->willReturn(new \stdClass());
+        $this->request->attributes = $attributes;
+
+        $this->assertNull($this->voter->matchItem($this->createItem(new \stdClass())));
+    }
+
+    protected function createItem($content = null)
+    {
+        $item = $this->prophesize(ItemInterface::class);
+        $item->getExtra('content')->willReturn($content);
+
+        return $item->reveal();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for avoiding deprecation warning with latest knp menu
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #303
| License       | MIT
| Doc PR        | https://github.com/symfony-cmf/symfony-cmf-docs/pull/843

I considered doing a trait for the logic with request stack, but decided against it. In the next major version bump, we will remove setRequest and can get rid of getRequest as well, making everything a lot simpler.