### PR TITLE
Add symfony/validator to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^7.1",
         "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
+        "symfony/validator": "^2.8 || ^3.3 || ^4.0",
         "knplabs/knp-menu-bundle": "^2.2.0",
         "knplabs/knp-menu": "^2.0.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master", for 2.1 release
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

In https://github.com/symfony-cmf/symfony-cmf/issues/260 i tried to create minimal recipes for SymfonyCMF bundles used in `symfony-cmf/symfony-cmf`

A recipe for `symfony-cmf/menu-bundle` could could contain these lines:

```yaml
cmf_menu:
    persistence:
        phpcr:
            enabled: true
```

With this PR `symfony/validator` package will be added to composer.json. Service `validator.builder` service is used in `ValidationPass` compiller pass