### PR TITLE
Fix typo in parameter name with manager name

### DIFF
--- a/src/CmfMenuBundle.php
+++ b/src/CmfMenuBundle.php
@@ -33,7 +33,7 @@ class CmfMenuBundle extends Bundle
                         realpath(__DIR__.'/Resources/config/doctrine-model') => 'Symfony\Cmf\Bundle\MenuBundle\Model',
                         realpath(__DIR__.'/Resources/config/doctrine-phpcr') => 'Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr',
                     ],
-                    ['cmf_menu.manager_name'],
+                    ['cmf_menu.persistence.phpcr.manager_name'],
                     false,
                     ['CmfMenuBundle' => 'Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr']
                 )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / the branch of the current release for fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc           | https://symfony.com/doc/2.0/cmf/bundles/menu/configuration.html

This PR fixes typo in parameter name that could hold the manager name.

This parameter is created from `cmf_menu.persistence.phpcr.manager_name` configuration parameter by [Symfony\Cmf\Bundle\MenuBundle\DependencyInjection\CmfMenuExtension::loadPhpcr](https://github.com/symfony-cmf/menu-bundle/blob/master/src/DependencyInjection/CmfMenuExtension.php#L72)