### PR TITLE
Allow knp-menu 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "php": "^7.1",
         "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
         "symfony/validator": "^2.8 || ^3.3 || ^4.0",
-        "knplabs/knp-menu-bundle": "^2.2.0",
-        "knplabs/knp-menu": "^2.0.0"
+        "knplabs/knp-menu-bundle": "^2.2 || ^3.0",
+        "knplabs/knp-menu": "^2.0 || ^3.0"
     },
     "require-dev": {
         "symfony/monolog-bundle": "~3.1",

--- a/src/Extension/ContentExtension.php
+++ b/src/Extension/ContentExtension.php
@@ -45,7 +45,7 @@ class ContentExtension implements ExtensionInterface
      *
      * @return array
      */
-    public function buildOptions(array $options)
+    public function buildOptions(array $options): array
     {
         $options = array_merge([
             'content' => null,
@@ -86,7 +86,7 @@ class ContentExtension implements ExtensionInterface
      * @param ItemInterface $item
      * @param array         $options
      */
-    public function buildItem(ItemInterface $item, array $options)
+    public function buildItem(ItemInterface $item, array $options): void
     {
     }
 

--- a/src/Loader/VotingNodeLoader.php
+++ b/src/Loader/VotingNodeLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Cmf\Bundle\MenuBundle\Loader;
 
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use Knp\Menu\Loader\NodeLoader;
 use Knp\Menu\NodeInterface;
 use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\Menu;
@@ -40,7 +41,7 @@ class VotingNodeLoader extends NodeLoader
         $this->dispatcher = $dispatcher;
     }
 
-    public function load($data)
+    public function load($data): ItemInterface
     {
         if (!$this->supports($data)) {
             throw new \InvalidArgumentException(sprintf(
@@ -52,21 +53,13 @@ class VotingNodeLoader extends NodeLoader
         $this->dispatcher->dispatch(Events::CREATE_ITEM_FROM_NODE, $event);
 
         if ($event->isSkipNode()) {
-            if ($data instanceof Menu) {
-                // create an empty menu root to avoid the knp menu from failing.
-                return $this->menuFactory->createItem('');
-            }
-
-            return;
+            // create an empty menu root to avoid the knp menu from failing.
+            return $this->menuFactory->createItem('');
         }
 
         $item = $event->getItem() ?: $this->menuFactory->createItem($data->getName(), $data->getOptions());
 
-        if (empty($item)) {
-            return;
-        }
-
-        if ($event->isSkipChildren()) {
+        if (empty($item) || $event->isSkipChildren()) {
             return $item;
         }
 

--- a/src/Model/MenuNode.php
+++ b/src/Model/MenuNode.php
@@ -145,7 +145,7 @@ class MenuNode extends MenuNodeBase implements
     /**
      * {@inheritdoc}
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         $options = parent::getOptions();
 

--- a/src/Model/MenuNodeBase.php
+++ b/src/Model/MenuNodeBase.php
@@ -172,7 +172,7 @@ class MenuNodeBase implements NodeInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -349,7 +349,7 @@ class MenuNodeBase implements NodeInterface
      *
      * @return NodeInterface[]
      */
-    public function getChildren()
+    public function getChildren(): \Traversable
     {
         $children = [];
         foreach ($this->children as $child) {
@@ -359,7 +359,7 @@ class MenuNodeBase implements NodeInterface
             $children[] = $child;
         }
 
-        return $children;
+        return new \ArrayIterator($children);
     }
 
     /**
@@ -573,7 +573,7 @@ class MenuNodeBase implements NodeInterface
     /**
      * {@inheritdoc}
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return [
             'uri' => $this->getUri(),

--- a/src/Provider/PhpcrMenuProvider.php
+++ b/src/Provider/PhpcrMenuProvider.php
@@ -140,7 +140,7 @@ class PhpcrMenuProvider implements MenuProviderInterface
      *
      * @throws \InvalidArgumentException if the menu can not be found
      */
-    public function get($name, array $options = [])
+    public function get(string $name, array $options = []): ItemInterface
     {
         $menu = $this->find($name, true);
 
@@ -164,7 +164,7 @@ class PhpcrMenuProvider implements MenuProviderInterface
      *
      * @return bool Whether a menu with this name can be loaded by this provider
      */
-    public function has($name, array $options = [])
+    public function has(string $name, array $options = []): bool
     {
         return $this->find($name, false) instanceof NodeInterface;
     }

--- a/src/QuietFactory.php
+++ b/src/QuietFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Cmf\Bundle\MenuBundle;
 
 use Knp\Menu\Factory\ExtensionInterface;
 use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
 use LogicException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -54,7 +55,7 @@ class QuietFactory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createItem($name, array $options = [])
+    public function createItem(string $name, array $options = []): ItemInterface
     {
         try {
             return $this->innerFactory->createItem($name, $options);
@@ -67,7 +68,7 @@ class QuietFactory implements FactoryInterface
             }
 
             if (!$this->allowEmptyItems) {
-                return;
+                return $this->innerFactory->createItem('');
             }
 
             // remove route and content options

--- a/src/Voter/UriPrefixVoter.php
+++ b/src/Voter/UriPrefixVoter.php
@@ -68,11 +68,11 @@ class UriPrefixVoter implements VoterInterface
     /**
      * {@inheritdoc}
      */
-    public function matchItem(ItemInterface $item)
+    public function matchItem(ItemInterface $item): ?bool
     {
         $request = $this->getRequest();
         if (!$request) {
-            return;
+            return false;
         }
 
         $content = $item->getExtra('content');
@@ -84,6 +84,8 @@ class UriPrefixVoter implements VoterInterface
                 return true;
             }
         }
+
+        return null;
     }
 
     private function getRequest()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| License       | MIT

Hi !

Since version [3.75.0](https://packagist.org/packages/sonata-project/admin-bundle#3.75.0), `sonata-project/admin-bundle` required `knplabs/menu-bundle` ^3.0. This is a PR to upgrade this bundle to the same version. As methods signatures changed, this is a BC break update. It works on my personnal project.

However I currently have an issue because in some methods we must now return a non-null `ItemInterface` item. Any ideas what could be a better fix than what I did ?
